### PR TITLE
Email Form

### DIFF
--- a/.editorconfig
+++ b/.editorconfig
@@ -1,0 +1,14 @@
+root = true
+
+[*]
+end_of_line = lf
+insert_final_newline = true
+trim_trailing_whitespace = true
+charset = utf-8
+indent_style = space
+indent_size = 2
+
+quote_type = single
+semi = true
+spaces_around_operators = true
+spaces_around_brackets = true

--- a/.env.example
+++ b/.env.example
@@ -1,0 +1,4 @@
+NEXT_PUBLIC_DEVELOPER_API_URL=https://api.onfabric.io
+NEXT_PUBLIC_CONSENT_APP_URL=https://consent.onfabric.io
+NEXT_PUBLIC_REDIRECT_URL=https://your-redirect-url.com
+ONFABRIC_API_KEY=secret-api-key

--- a/.gitignore
+++ b/.gitignore
@@ -32,6 +32,7 @@ yarn-error.log*
 
 # env files (can opt-in for committing if needed)
 .env*
+!.env.example
 
 # vercel
 .vercel

--- a/package-lock.json
+++ b/package-lock.json
@@ -8,7 +8,9 @@
       "name": "onfabric-redirect",
       "version": "0.1.0",
       "dependencies": {
+        "@hookform/resolvers": "^3.10.0",
         "@radix-ui/react-avatar": "^1.1.2",
+        "@radix-ui/react-label": "^2.1.1",
         "@radix-ui/react-slot": "^1.1.1",
         "axios": "^1.7.9",
         "class-variance-authority": "^0.7.1",
@@ -18,8 +20,10 @@
         "next-themes": "^0.4.4",
         "react": "^19.0.0",
         "react-dom": "^19.0.0",
+        "react-hook-form": "^7.54.2",
         "tailwind-merge": "^2.6.0",
-        "tailwindcss-animate": "^1.0.7"
+        "tailwindcss-animate": "^1.0.7",
+        "zod": "^3.24.1"
       },
       "devDependencies": {
         "@eslint/eslintrc": "^3",
@@ -181,6 +185,15 @@
       },
       "engines": {
         "node": "^18.18.0 || ^20.9.0 || >=21.1.0"
+      }
+    },
+    "node_modules/@hookform/resolvers": {
+      "version": "3.10.0",
+      "resolved": "https://registry.npmjs.org/@hookform/resolvers/-/resolvers-3.10.0.tgz",
+      "integrity": "sha512-79Dv+3mDF7i+2ajj7SkypSKHhl1cbln1OGavqrsF7p6mbUv11xpqpacPsGDCTRvCSjEEIez2ef1NveSVL3b0Ag==",
+      "license": "MIT",
+      "peerDependencies": {
+        "react-hook-form": "^7.0.0"
       }
     },
     "node_modules/@humanfs/core": {
@@ -926,6 +939,29 @@
       },
       "peerDependenciesMeta": {
         "@types/react": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/@radix-ui/react-label": {
+      "version": "2.1.1",
+      "resolved": "https://registry.npmjs.org/@radix-ui/react-label/-/react-label-2.1.1.tgz",
+      "integrity": "sha512-UUw5E4e/2+4kFMH7+YxORXGWggtY6sM8WIwh5RZchhLuUg2H1hc98Py+pr8HMz6rdaYrK2t296ZEjYLOCO5uUw==",
+      "license": "MIT",
+      "dependencies": {
+        "@radix-ui/react-primitive": "2.0.1"
+      },
+      "peerDependencies": {
+        "@types/react": "*",
+        "@types/react-dom": "*",
+        "react": "^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc",
+        "react-dom": "^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc"
+      },
+      "peerDependenciesMeta": {
+        "@types/react": {
+          "optional": true
+        },
+        "@types/react-dom": {
           "optional": true
         }
       }
@@ -4784,6 +4820,22 @@
         "react": "^19.0.0"
       }
     },
+    "node_modules/react-hook-form": {
+      "version": "7.54.2",
+      "resolved": "https://registry.npmjs.org/react-hook-form/-/react-hook-form-7.54.2.tgz",
+      "integrity": "sha512-eHpAUgUjWbZocoQYUHposymRb4ZP6d0uwUnooL2uOybA9/3tPUvoAKqEWK1WaSiTxxOfTpffNZP7QwlnM3/gEg==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=18.0.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/react-hook-form"
+      },
+      "peerDependencies": {
+        "react": "^16.8.0 || ^17 || ^18 || ^19"
+      }
+    },
     "node_modules/react-is": {
       "version": "16.13.1",
       "resolved": "https://registry.npmjs.org/react-is/-/react-is-16.13.1.tgz",
@@ -6073,6 +6125,15 @@
       },
       "funding": {
         "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
+    "node_modules/zod": {
+      "version": "3.24.1",
+      "resolved": "https://registry.npmjs.org/zod/-/zod-3.24.1.tgz",
+      "integrity": "sha512-muH7gBL9sI1nciMZV67X5fTKKBLtwpZ5VBp1vsOQzj1MhrBZ4wlVCm3gedKZWLp0Oyel8sIGfeiz54Su+OVT+A==",
+      "license": "MIT",
+      "funding": {
+        "url": "https://github.com/sponsors/colinhacks"
       }
     }
   }

--- a/package.json
+++ b/package.json
@@ -9,7 +9,9 @@
     "lint": "next lint"
   },
   "dependencies": {
+    "@hookform/resolvers": "^3.10.0",
     "@radix-ui/react-avatar": "^1.1.2",
+    "@radix-ui/react-label": "^2.1.1",
     "@radix-ui/react-slot": "^1.1.1",
     "axios": "^1.7.9",
     "class-variance-authority": "^0.7.1",
@@ -19,8 +21,10 @@
     "next-themes": "^0.4.4",
     "react": "^19.0.0",
     "react-dom": "^19.0.0",
+    "react-hook-form": "^7.54.2",
     "tailwind-merge": "^2.6.0",
-    "tailwindcss-animate": "^1.0.7"
+    "tailwindcss-animate": "^1.0.7",
+    "zod": "^3.24.1"
   },
   "devDependencies": {
     "@eslint/eslintrc": "^3",

--- a/src/app/consent/[consentSlug]/consent.tsx
+++ b/src/app/consent/[consentSlug]/consent.tsx
@@ -28,17 +28,17 @@ export default function Consent(props: { consentSlug: string, userId?: string })
         window.location.replace(`${process.env.NEXT_PUBLIC_CONSENT_APP_URL}/consent/${props.consentSlug}?token=${response.token}`);
       });
     }
-  }, [inAppBrowser]);
+  }, [inAppBrowser, props.consentSlug, props.userId]);
 
   return (
-    <div className="flex flex-col items-center text-center h-screen max-w-xl m-auto pt-16 pb-4 px-4">
+    <div className="flex flex-col items-center h-screen max-w-xl m-auto pt-16 pb-4 px-6">
       <Avatar>
         <AvatarImage src="/logo-icon-dark.svg" alt="Fabric Logo"/>
       </Avatar>
-      <h1 className="mt-12 text-2xl font-bold">
+      <h1 className="mt-12 text-2xl font-bold text-center">
         { inAppBrowser ? "In-app Browser Detected" : "Redirecting..." }
       </h1>
-      <p className="px-8 mt-4">
+      <p className="px-8 mt-4 text-center">
         { inAppBrowser ? "We’ve detected that you’re using an in-app browser. For the best experience, please open the link in your default browser." : "We will redirect you through our consent flow shortly." }
       </p>
     </div>

--- a/src/app/consent/[consentSlug]/page.tsx
+++ b/src/app/consent/[consentSlug]/page.tsx
@@ -1,4 +1,4 @@
-import Consent from './consent';
+import Consent from "./consent";
 
 type ConsentRedirectParams = {
   consentSlug: string;
@@ -13,10 +13,9 @@ type ConsentRedirectProps = {
   searchParams: Promise<ConsentRedirectSearchParams>;
 };
 
-export default async function Home(props: ConsentRedirectProps) {
+export default async function ConsentPage(props: ConsentRedirectProps) {
   const { consentSlug } = await props.params;
   const { userId } = await props.searchParams;
-
   return (
     <Consent userId={userId} consentSlug={consentSlug}/>
   )

--- a/src/app/details/actions.ts
+++ b/src/app/details/actions.ts
@@ -1,0 +1,48 @@
+"use server";
+
+import axios from "axios";
+
+const axiosInstance = axios.create({
+  baseURL: process.env.NEXT_PUBLIC_DEVELOPER_API_URL,
+});
+
+export type CallbackUrlResponse = {
+  callback_url: string;
+  external_id: string;
+};
+
+export async function getExternalUserId(
+  state: string
+) {
+  const response = await axiosInstance.request<CallbackUrlResponse>({
+    method: "GET",
+    url: `/api/v1/public/link/callback_url/${state}`,
+  });
+  
+  if (response.status !== 200) {
+    throw new Error("Failed to get external user id");
+  }
+
+  return response.data.external_id;
+}
+
+export async function updateLinkUserEmail(
+  userId: string,
+  email: string
+) {
+  const response = await axiosInstance.request({
+    method: "PUT",
+    url: "/api/v1/link/email",
+    params: {
+      user_id: userId,
+      email,
+    },
+    headers: {
+      "Api-Key": process.env.ONFABRIC_API_KEY,
+    }
+  });
+
+  if (response.status !== 200) {
+    throw new Error("Failed to update link user email");
+  }
+}

--- a/src/app/details/details.tsx
+++ b/src/app/details/details.tsx
@@ -1,0 +1,85 @@
+"use client";
+
+import { zodResolver } from "@hookform/resolvers/zod";
+import { useForm } from "react-hook-form";
+import { z } from "zod";
+
+import { updateLinkUserEmail } from './actions';
+
+import { Button } from "@/components/ui/button";
+import { Loader2 } from "lucide-react";
+
+import {
+  Form,
+  FormControl,
+  FormField,
+  FormItem,
+  FormLabel,
+  FormMessage,
+} from "@/components/ui/form";
+import { Input } from "@/components/ui/input";
+import { useEffect, useState } from "react";
+
+const FormSchema = z.object({
+  email: z.string().email({ message: "Email address must be valid" }),
+});
+
+export default function DetailsForm(props: { externalId: string }) {
+  const form = useForm<z.infer<typeof FormSchema>>({
+    resolver: zodResolver(FormSchema),
+    defaultValues: {
+      email: "",
+    },
+  })
+
+  const [formMessage, setFormMessage] = useState("");
+
+  useEffect(() => {
+    if (formMessage) {      
+      setTimeout(() => {
+        setFormMessage("");
+      }, 3000);
+    }
+  }, [formMessage])
+
+  async function onSubmit(data: z.infer<typeof FormSchema>) {
+    try {
+      await updateLinkUserEmail(props.externalId, data.email);
+      window.location.replace(`${process.env.NEXT_PUBLIC_REDIRECT_URL}?userId=${props.externalId}`);
+    } catch (err) {
+      console.log(err);
+      setFormMessage("An error occurred. Please try again.");
+    }
+  }
+
+  return (
+    <Form {...form}>
+      <form onSubmit={form.handleSubmit(onSubmit)} className="w-full space-y-6 mt-12">
+        <FormField
+          control={form.control}
+          name="email"
+          render={({ field }) => (
+            <FormItem>
+              <FormLabel className="font-bold">Email</FormLabel>
+              <div className="flex space-x-2">
+                <FormControl>
+                  <Input placeholder="Email" {...field} />
+                </FormControl>
+                <Button disabled={form.formState.isSubmitting} type="submit" className="flex items-center justify-center px-4 py-2 min-w-[70]">
+                  {form.formState.isSubmitting ? (
+                    <Loader2 className="animate-spin" />
+                  ) : (
+                    <span>Submit</span>
+                  )}
+                </Button>
+              </div>
+              <FormMessage>
+                {formMessage}
+              </FormMessage>
+            </FormItem>
+          )}
+        />
+      </form>
+    </Form>
+  )
+}

--- a/src/app/details/page.tsx
+++ b/src/app/details/page.tsx
@@ -1,0 +1,34 @@
+import { Avatar, AvatarImage } from '@/components/ui/avatar';
+import { getExternalUserId } from './actions';
+import DetailsForm from './details';
+import { redirect } from 'next/navigation';
+
+type DetailsSearchParams = {
+  state: string;
+};
+
+type DetailsProps = {
+  searchParams: Promise<DetailsSearchParams>;
+};
+
+export default async function DetailsPage(props: DetailsProps) {
+  const { state } = await props.searchParams;
+
+  try {
+    const externalId = await getExternalUserId(state);
+    return (
+      <div className="flex flex-col items-center h-screen max-w-xl m-auto pt-16 pb-4 px-6">
+        <Avatar>
+          <AvatarImage src="/logo-icon-dark.svg" alt="Fabric Logo"/>
+        </Avatar>
+        <h1 className="mt-12 text-2xl font-bold text-center">
+          Please enter your details so we can associate it with your data.
+        </h1>
+        <DetailsForm externalId={externalId} />
+      </div>
+    );
+  } catch (err) {
+    console.error(err);
+    redirect(`${process.env.NEXT_PUBLIC_REDIRECT_URL}?error=INVALID_STATE`)
+  }
+}

--- a/src/components/ui/button.tsx
+++ b/src/components/ui/button.tsx
@@ -1,0 +1,56 @@
+import * as React from "react"
+import { Slot } from "@radix-ui/react-slot"
+import { cva, type VariantProps } from "class-variance-authority"
+
+import { cn } from "@/lib/utils"
+
+const buttonVariants = cva(
+  "inline-flex items-center justify-center gap-2 whitespace-nowrap rounded-md text-sm font-medium ring-offset-background transition-colors focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-ring focus-visible:ring-offset-2 disabled:pointer-events-none disabled:opacity-50 [&_svg]:pointer-events-none [&_svg]:size-4 [&_svg]:shrink-0",
+  {
+    variants: {
+      variant: {
+        default: "bg-primary text-primary-foreground hover:bg-primary/90",
+        destructive:
+          "bg-destructive text-destructive-foreground hover:bg-destructive/90",
+        outline:
+          "border border-input bg-background hover:bg-accent hover:text-accent-foreground",
+        secondary:
+          "bg-secondary text-secondary-foreground hover:bg-secondary/80",
+        ghost: "hover:bg-accent hover:text-accent-foreground",
+        link: "text-primary underline-offset-4 hover:underline",
+      },
+      size: {
+        default: "h-10 px-4 py-2",
+        sm: "h-9 rounded-md px-3",
+        lg: "h-11 rounded-md px-8",
+        icon: "h-10 w-10",
+      },
+    },
+    defaultVariants: {
+      variant: "default",
+      size: "default",
+    },
+  }
+)
+
+export interface ButtonProps
+  extends React.ButtonHTMLAttributes<HTMLButtonElement>,
+    VariantProps<typeof buttonVariants> {
+  asChild?: boolean
+}
+
+const Button = React.forwardRef<HTMLButtonElement, ButtonProps>(
+  ({ className, variant, size, asChild = false, ...props }, ref) => {
+    const Comp = asChild ? Slot : "button"
+    return (
+      <Comp
+        className={cn(buttonVariants({ variant, size, className }))}
+        ref={ref}
+        {...props}
+      />
+    )
+  }
+)
+Button.displayName = "Button"
+
+export { Button, buttonVariants }

--- a/src/components/ui/form.tsx
+++ b/src/components/ui/form.tsx
@@ -1,0 +1,178 @@
+"use client"
+
+import * as React from "react"
+import * as LabelPrimitive from "@radix-ui/react-label"
+import { Slot } from "@radix-ui/react-slot"
+import {
+  Controller,
+  ControllerProps,
+  FieldPath,
+  FieldValues,
+  FormProvider,
+  useFormContext,
+} from "react-hook-form"
+
+import { cn } from "@/lib/utils"
+import { Label } from "@/components/ui/label"
+
+const Form = FormProvider
+
+type FormFieldContextValue<
+  TFieldValues extends FieldValues = FieldValues,
+  TName extends FieldPath<TFieldValues> = FieldPath<TFieldValues>
+> = {
+  name: TName
+}
+
+const FormFieldContext = React.createContext<FormFieldContextValue>(
+  {} as FormFieldContextValue
+)
+
+const FormField = <
+  TFieldValues extends FieldValues = FieldValues,
+  TName extends FieldPath<TFieldValues> = FieldPath<TFieldValues>
+>({
+  ...props
+}: ControllerProps<TFieldValues, TName>) => {
+  return (
+    <FormFieldContext.Provider value={{ name: props.name }}>
+      <Controller {...props} />
+    </FormFieldContext.Provider>
+  )
+}
+
+const useFormField = () => {
+  const fieldContext = React.useContext(FormFieldContext)
+  const itemContext = React.useContext(FormItemContext)
+  const { getFieldState, formState } = useFormContext()
+
+  const fieldState = getFieldState(fieldContext.name, formState)
+
+  if (!fieldContext) {
+    throw new Error("useFormField should be used within <FormField>")
+  }
+
+  const { id } = itemContext
+
+  return {
+    id,
+    name: fieldContext.name,
+    formItemId: `${id}-form-item`,
+    formDescriptionId: `${id}-form-item-description`,
+    formMessageId: `${id}-form-item-message`,
+    ...fieldState,
+  }
+}
+
+type FormItemContextValue = {
+  id: string
+}
+
+const FormItemContext = React.createContext<FormItemContextValue>(
+  {} as FormItemContextValue
+)
+
+const FormItem = React.forwardRef<
+  HTMLDivElement,
+  React.HTMLAttributes<HTMLDivElement>
+>(({ className, ...props }, ref) => {
+  const id = React.useId()
+
+  return (
+    <FormItemContext.Provider value={{ id }}>
+      <div ref={ref} className={cn("space-y-2", className)} {...props} />
+    </FormItemContext.Provider>
+  )
+})
+FormItem.displayName = "FormItem"
+
+const FormLabel = React.forwardRef<
+  React.ElementRef<typeof LabelPrimitive.Root>,
+  React.ComponentPropsWithoutRef<typeof LabelPrimitive.Root>
+>(({ className, ...props }, ref) => {
+  const { error, formItemId } = useFormField()
+
+  return (
+    <Label
+      ref={ref}
+      className={cn(error && "text-destructive", className)}
+      htmlFor={formItemId}
+      {...props}
+    />
+  )
+})
+FormLabel.displayName = "FormLabel"
+
+const FormControl = React.forwardRef<
+  React.ElementRef<typeof Slot>,
+  React.ComponentPropsWithoutRef<typeof Slot>
+>(({ ...props }, ref) => {
+  const { error, formItemId, formDescriptionId, formMessageId } = useFormField()
+
+  return (
+    <Slot
+      ref={ref}
+      id={formItemId}
+      aria-describedby={
+        !error
+          ? `${formDescriptionId}`
+          : `${formDescriptionId} ${formMessageId}`
+      }
+      aria-invalid={!!error}
+      {...props}
+    />
+  )
+})
+FormControl.displayName = "FormControl"
+
+const FormDescription = React.forwardRef<
+  HTMLParagraphElement,
+  React.HTMLAttributes<HTMLParagraphElement>
+>(({ className, ...props }, ref) => {
+  const { formDescriptionId } = useFormField()
+
+  return (
+    <p
+      ref={ref}
+      id={formDescriptionId}
+      className={cn("text-sm text-muted-foreground", className)}
+      {...props}
+    />
+  )
+})
+FormDescription.displayName = "FormDescription"
+
+const FormMessage = React.forwardRef<
+  HTMLParagraphElement,
+  React.HTMLAttributes<HTMLParagraphElement>
+>(({ className, children, ...props }, ref) => {
+  const { error, formMessageId } = useFormField()
+  const body = error ? String(error?.message) : children
+
+  if (!body) {
+    return null
+  }
+
+  return (
+    <p
+      ref={ref}
+      id={formMessageId}
+      className={cn("text-sm font-medium text-destructive", className)}
+      {...props}
+    >
+      {body}
+    </p>
+  )
+})
+FormMessage.displayName = "FormMessage"
+
+export {
+  useFormField,
+  Form,
+  FormItem,
+  FormLabel,
+  FormControl,
+  FormDescription,
+  FormMessage,
+  FormField,
+}

--- a/src/components/ui/input.tsx
+++ b/src/components/ui/input.tsx
@@ -1,0 +1,22 @@
+import * as React from "react"
+
+import { cn } from "@/lib/utils"
+
+const Input = React.forwardRef<HTMLInputElement, React.ComponentProps<"input">>(
+  ({ className, type, ...props }, ref) => {
+    return (
+      <input
+        type={type}
+        className={cn(
+          "flex h-10 w-full rounded-md border border-input bg-background px-3 py-2 text-base ring-offset-background file:border-0 file:bg-transparent file:text-sm file:font-medium file:text-foreground placeholder:text-muted-foreground focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-ring focus-visible:ring-offset-2 disabled:cursor-not-allowed disabled:opacity-50 md:text-sm",
+          className
+        )}
+        ref={ref}
+        {...props}
+      />
+    )
+  }
+)
+Input.displayName = "Input"
+
+export { Input }

--- a/src/components/ui/label.tsx
+++ b/src/components/ui/label.tsx
@@ -1,0 +1,26 @@
+"use client"
+
+import * as React from "react"
+import * as LabelPrimitive from "@radix-ui/react-label"
+import { cva, type VariantProps } from "class-variance-authority"
+
+import { cn } from "@/lib/utils"
+
+const labelVariants = cva(
+  "text-sm font-medium leading-none peer-disabled:cursor-not-allowed peer-disabled:opacity-70"
+)
+
+const Label = React.forwardRef<
+  React.ElementRef<typeof LabelPrimitive.Root>,
+  React.ComponentPropsWithoutRef<typeof LabelPrimitive.Root> &
+    VariantProps<typeof labelVariants>
+>(({ className, ...props }, ref) => (
+  <LabelPrimitive.Root
+    ref={ref}
+    className={cn(labelVariants(), className)}
+    {...props}
+  />
+))
+Label.displayName = LabelPrimitive.Root.displayName
+
+export { Label }


### PR DESCRIPTION
Implemented email form screen so we can capture the users email after they have given us consent to download their data. After the user submits their email they are are redirected along with the `userId`. If the state does not exist they are redirected with an error message.

**Task:** https://www.notion.so/onfabric/Create-Email-Form-Page-17b17f2992a28062a3fcd1501a2e9438?pvs=4

**Testing:**
- [x] Go to https://redirect-dev.onfabric.io/details?state=97229930-c6ff-4cbb-82d7-a243211b47a2 (This will pull down the externalId of the user that has completed a consent)
- [ ] Enter a valid email address and press submit
- [ ] Assert redirected to env.NEXT_PUBLIC_REDIRECT_URL?user_id=<user_id> (we can modify this redirect url as required)
- [ ] Assert redirected to env.NEXT_PUBLIC_REDIRECT_URL?error=INVALID_STATE if an invalid state uuid is given in step 1

**Screenshot:**
![image](https://github.com/user-attachments/assets/984debbe-fa0f-4252-bb2a-4e50abf113c0)